### PR TITLE
Use local canvas-confetti dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.45.1",
+        "canvas-confetti": "^1.9.3",
         "d3": "^7.9.0",
         "faunadb": "^4.8.0",
         "vue": "^3.4.29",
@@ -2301,6 +2302,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvas-confetti": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/canvas-confetti/-/canvas-confetti-1.9.3.tgz",
+      "integrity": "sha512-rFfTURMvmVEX1gyXFgn5QMn81bYk70qa0HLzcIOSVEyl57n6o9ItHeBtUSWdvKAPY0xlvBHno4/v3QPrT83q9g==",
+      "license": "ISC",
+      "funding": {
+        "type": "donate",
+        "url": "https://www.paypal.me/kirilvatev"
+      }
     },
     "node_modules/chalk": {
       "version": "2.4.2",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.45.1",
+    "canvas-confetti": "^1.9.3",
     "d3": "^7.9.0",
     "faunadb": "^4.8.0",
     "vue": "^3.4.29",

--- a/src/components/BlueGreenTest.vue
+++ b/src/components/BlueGreenTest.vue
@@ -175,7 +175,7 @@ import { MAX_ROUNDS, BIN_POSITION, BIN_COUNT, X_CDF, Y_CDF } from '@/config' // 
 
 <script>
 import { MAX_ROUNDS, VERSION, BIN_POSITION, BIN_COUNT, X_CDF, Y_CDF } from '@/config'
-import confetti from 'https://cdn.skypack.dev/canvas-confetti'
+import confetti from 'canvas-confetti'
 import Results from './Results.vue'
 import { fitSigmoid } from '@/utils/glmUtils'
 


### PR DESCRIPTION
## Summary

The app was crashing because the cdn used for the confetti library is no longer available.

Switches confetti to the local canvas-confetti dependency instead of loading from the CDN

